### PR TITLE
u-boot-compulab_2020.04: Add bison as compile dependency

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-bsp/u-boot/u-boot-compulab_2020.04.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-bsp/u-boot/u-boot-compulab_2020.04.bbappend
@@ -3,6 +3,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 UBOOT_KCONFIG_SUPPORT = "1"
 inherit resin-u-boot
 
+DEPENDS = "bison-native"
+
 SRC_URI_remove = " \
 	file://resin-specific-env-integration-kconfig.patch \
 "


### PR DESCRIPTION
Compilation of u-boot needs bison either as a host tool or as a native
package so let's add a compile dependency on bison-native here.

Changelog-entry: Fix u-boot compile error that needed bison-native dependency
Signed-off-by: Florin Sarbu <florin@balena.io>