### PR TITLE
u-boot-scr: Add u-boot-script

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-bsp/u-boot-scr/u-boot-script.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-bsp/u-boot-scr/u-boot-script.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+do_compile_prepend() {
+	BOOTLOADER=$(basename $(ls ${WORKDIR}/recipe-sysroot/boot/imx-boot-* | head -1))
+	sed -i "s|##BOOTLOADER##|${BOOTLOADER}|" ${WORKDIR}/boot.script
+}
+
+DEPENDS += "imx-boot"

--- a/layers/meta-balena-imx8mm/recipes-bsp/u-boot-scr/u-boot-script/iot-gate-imx8/boot.script
+++ b/layers/meta-balena-imx8mm/recipes-bsp/u-boot-scr/u-boot-script/iot-gate-imx8/boot.script
@@ -1,0 +1,36 @@
+setenv nload ${loadaddr}
+setenv oload ${fdt_addr}
+setenv mmcdev 2
+setenv mmcpart 1
+setenv mmcoff 0x42
+setenv bsize 0xB00
+setenv bootloader ##BOOTLOADER##
+
+# Load the new booloader from the file system
+# iface/dev/part defined by the default u-boot environment
+# the boot.scr has been loaded from
+# the same location must have the device bootloader
+if load ${iface} ${dev}:2 ${nload} boot/${bootloader}
+then
+
+    # Read the current booloader from the boot device
+    mmc dev ${mmcdev} ${mmcpart}
+    mmc read ${oload} ${mmcoff} ${bsize}
+
+    # Compare the old & the new one.
+    if cmp.b ${nload} ${oload} ${filesize}
+    then
+        echo Nothing to update
+    else
+        echo Updating the bootloader on mmc [${mmcdev}:${mmcpart}]
+        mmc write ${nload} ${mmcoff} ${bsize}
+        mmc partconf ${mmcdev} 0 ${mmcpart} 0
+        reset
+    fi
+
+else
+    echo ##BOOTLOADER## file not found
+fi
+
+setenv script
+boot

--- a/layers/meta-balena-imx8mm/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-core/images/resin-image.bbappend
@@ -1,5 +1,6 @@
 include resin-image.inc
 
 RESIN_BOOT_PARTITION_FILES_append_iot-gate-imx8 = " \
-    imx-boot-${MACHINE}-sd.bin-flash_evk:\
+    imx-boot-${MACHINE}-sd.bin-flash_evk: \
+    boot.scr: \
 "


### PR DESCRIPTION
In order to be able to flash the iot-gate-imx8,
with the BalenaOS, the Balena u-boot must be
written in the internal eMMC board memory.
This will be done by u-boot-script which will
load a script that will do that automatically
without the need for user intervention

Changelog-entry: Add u-boot-script for u-boot re-writing
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>