### PR TITLE
recipes-core/images: Update RESIN_BOOT_PARTITION_FILES

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-core/images/resin-image-flasher.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-core/images/resin-image-flasher.bbappend
@@ -1,1 +1,5 @@
 include resin-image.inc
+
+RESIN_BOOT_PARTITION_FILES_append_iot-gate-imx8 = " \
+    boot.scr:/boot.scr \
+"

--- a/layers/meta-balena-imx8mm/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-core/images/resin-image.bbappend
@@ -1,6 +1,1 @@
 include resin-image.inc
-
-RESIN_BOOT_PARTITION_FILES_append_iot-gate-imx8 = " \
-    imx-boot-${MACHINE}-sd.bin-flash_evk: \
-    boot.scr: \
-"


### PR DESCRIPTION
Remove imx-boot-${MACHINE}-sd.bin-flash_evk from boot
partition files for the Balena image and add boot.scr
to the Balena flasher image.
The flash_evk is not used on the boot partition of the
flasher image. The boot.scr is the script that re-writes
the bootloader using the USB as source

Changelog-entry: Update RESIN_BOOT_PARTITION_FILES
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>