### PR TITLE
resin-image.bbappend: Add imx-boot-${MACHINE}-sd.bin-flash_evk to boo…

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-core/images/resin-image.bbappend
@@ -1,1 +1,5 @@
 include resin-image.inc
+
+RESIN_BOOT_PARTITION_FILES_append_iot-gate-imx8 = " \
+    imx-boot-${MACHINE}-sd.bin-flash_evk: \
+"


### PR DESCRIPTION
…t partition

Add imx-boot-${MACHINE}-sd.bin-flash_evk to the
boot partition for the Balena image (non-flasher).
This change is needed for the hostupdate hook

Changelog-entry: Add flash_evk to boot partition
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>