### PR TITLE
99-flash-bootloader: Set correct mmcblk device

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
+++ b/layers/meta-balena-imx8mm/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
@@ -12,7 +12,7 @@ uboot_file="imx-boot-iot-gate-imx8-sd.bin-flash_evk"
 uboot_block_size=1024
 uboot_seek_blocks=33
 
-device="/dev/mmcblk0"
+device="/dev/mmcblk2"
 
 update_files="uboot"
 


### PR DESCRIPTION
Set /dev/mmcblk2 as the device to be update when
running hostappupdate

Changelog-entry: Set correct mmcblk device for hostappupdate
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>