### PR TITLE
conf/layer: Remove vendor console resize scripts

### DIFF
--- a/layers/meta-balena-imx8mm/conf/layer.conf
+++ b/layers/meta-balena-imx8mm/conf/layer.conf
@@ -13,6 +13,8 @@ BBMASK += "u-boot-imx-fw-utils_2019.04.bb"
 BBMASK += "compulab-qt5-build-env.bb"
 BBMASK += "u-boot-fw-utils_%.bbappend"
 BBMASK += "packagegroup-resin-connectivity.bbappend"
+BBMASK += "meta-compulab-bsp/meta-bsp/recipes-bsp/base-files/"
+
 
 PREFERRED_PROVIDER_virtual/kernel_iot-gate-imx8 = "linux-compulab"
 PREFERRED_PROVIDER_virtual/bootloader_iot-gate-imx8 = "u-boot-compulab"


### PR DESCRIPTION
The Compulab BSP adds a couple scripts that call
resize on the terminal without redirecting stderr.
This has the effect of having unwanted output from
resize getting printed on the screen, as well as dashboard
trigered HUP exiting right at the beginning.

Mask these recipes to exclude them from our images.

Changelog-entry: conf/layer: Remove vendor console resize scripts
Signed-off-by: Alexandru Costache <alexandru@balena.io>