### PR TITLE
balena-iot-gate-imx8: rename connectivity packagegroup

### DIFF
--- a/layers/meta-balena-imx8mm/conf/layer.conf
+++ b/layers/meta-balena-imx8mm/conf/layer.conf
@@ -12,7 +12,7 @@ BBMASK += "compulab-ucm-imx8m-mini.bb"
 BBMASK += "u-boot-imx-fw-utils_2019.04.bb"
 BBMASK += "compulab-qt5-build-env.bb"
 BBMASK += "u-boot-fw-utils_%.bbappend"
-BBMASK += "packagegroup-resin-connectivity.bbappend"
+BBMASK += "packagegroup-balena-connectivity.bbappend"
 BBMASK += "meta-compulab-bsp/meta-bsp/recipes-bsp/base-files/"
 
 


### PR DESCRIPTION
Rename `packagegroup-resin-connectivity` to `packagegroup-balena-connectivity` and update all references.

This PR needs to be merged when balena-os/meta-balena#2187 has been merged.

Change-type: patch
Changelog-entry: balena-iot-gate-imx8: rename connectivity packagegroup
Signed-off-by: Mark Corbin <mark@balena.io>