### PR TITLE
meta-balena-imx8mm:layer.conf: Fix typo for u-boot-fw-utils provider

### DIFF
--- a/layers/meta-balena-imx8mm/conf/layer.conf
+++ b/layers/meta-balena-imx8mm/conf/layer.conf
@@ -18,7 +18,7 @@ BBMASK += "meta-compulab-bsp/meta-bsp/recipes-bsp/base-files/"
 
 PREFERRED_PROVIDER_virtual/kernel_iot-gate-imx8 = "linux-compulab"
 PREFERRED_PROVIDER_virtual/bootloader_iot-gate-imx8 = "u-boot-compulab"
-PREFERRED_RROVIDER_u-boot-fw-utils_iot-gate-imx8 = "u-boot-compulab-fw-utils"
+PREFERRED_RPROVIDER_u-boot-fw-utils_iot-gate-imx8 = "u-boot-compulab-fw-utils"
 
 CORE_IMAGE_EXTRA_INSTALL_iot-gate-imx8 += " cl-uboot cl-deploy u-boot-script "
 CORE_IMAGE_EXTRA_INSTALL_iot-gate-imx8 += " u-boot-fw-utils modemmanager networkmanager linux-firmware-ax200"


### PR DESCRIPTION
Changelog-entry: Fix typo that prevented setting the preferred provider as u-boot-compulab-fw-utils for u-boot-fw-utils
Signed-off-by: Florin Sarbu <florin@balena.io>