### PR TITLE
balena-image-flasher: Remove kernel from boot partition

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-core/images/balena-image-flasher.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-core/images/balena-image-flasher.bbappend
@@ -2,5 +2,4 @@ include balena-image.inc
 
 BALENA_BOOT_PARTITION_FILES_append_iot-gate-imx8 = " \
     boot.scr:/boot.scr \
-    ${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin:/Image.gz \
 "


### PR DESCRIPTION
This DT can boot the flasher image only with a balena u-boot. Since balena u-boot knows how to load the image from the rootfs, the kernel can be removed from the boot partition, because the total size of the contents there now exceed half of the filesystem size.


Changelog-entry: balena-image-flasher: Remove kernel from boot partition