### PR TITLE
conf/layer: Mask meta-balena ModemManager recipes

### DIFF
--- a/layers/meta-balena-imx8mm/conf/layer.conf
+++ b/layers/meta-balena-imx8mm/conf/layer.conf
@@ -28,6 +28,13 @@ BBMASK += "meta-compulab/recipes-desktop"
 BBMASK += "meta-compulab/classes/compulab.bbclass"
 BBMASK += "meta-bsp-imx8mm/recipes-bsp/recipes-images"
 
+# These need to be masked until the MM update PR is merged
+# in meta-balena and we can drop the existing update files in this
+# repository
+BBMASK += "meta-balena/meta-balena-common/recipes-connectivity/modemmanager"
+BBMASK += "meta-balena/meta-balena-common/recipes-connectivity/libqmi"
+BBMASK += "meta-balena/meta-balena-common/recipes-connectivity/libmbim"
+
 # These should be removed once the Modemmanager update
 # is merged in meta-balena
 PREFERRED_VERSION:libmbim = "1.28.4"


### PR DESCRIPTION
Until they are merged and we can remove the existing recipes in this repository. Without this, the MM update PR cannot be built because the patches would be applied twice.

Changelog-entry: conf/layer: Mask meta-balena ModemManager recipes

Allows building and merging of https://github.com/balena-os/meta-balena/pull/3184