### PR TITLE
conf/layer: Remove leftover MM libraries pinning

### DIFF
--- a/layers/meta-balena-imx8mm/conf/layer.conf
+++ b/layers/meta-balena-imx8mm/conf/layer.conf
@@ -28,12 +28,6 @@ BBMASK += "meta-compulab/recipes-desktop"
 BBMASK += "meta-compulab/classes/compulab.bbclass"
 BBMASK += "meta-bsp-imx8mm/recipes-bsp/recipes-images"
 
-# These should be removed once the Modemmanager update
-# is merged in meta-balena
-PREFERRED_VERSION:libmbim = "1.28.4"
-PREFERRED_VERSION:libqmi = "1.32.4"
-PREFERRED_VERSION:modemmanager = "1.20.6"
-
 CORE_IMAGE_EXTRA_INSTALL:iot-gate-imx8 += " cl-uboot cl-deploy u-boot-script "
 CORE_IMAGE_EXTRA_INSTALL:iot-gate-imx8 += " u-boot-fw-utils modemmanager networkmanager linux-firmware-ax200"
 CORE_IMAGE_EXTRA_INSTALL:remove = "firmware-imx-sdma-imx7d"


### PR DESCRIPTION
Because these pinning could cause problems when MM or one of it's dependencies get updated in meta-balena.

Changelog-entry: conf/layer: Remove leftover MM libraries pinning