### PR TITLE
Fix kernel not to freeze on kexec

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab/iot-gate-imx8-release-3.2.2.1.patch
+++ b/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab/iot-gate-imx8-release-3.2.2.1.patch
@@ -1,0 +1,23 @@
+From: Alex Gonzalez <alexg@balena.io>
+Date: Wed, 16 Oct 2024 11:32:04 +0000
+Subject: [PATCH] iot-gate-imx8: release 3.2.2.1
+
+Increase local version so we can identify at which point the kernel got
+the kexec fixes. This allows runtime to know whether it's safe to kexec
+into the kernel.
+
+Signed-off-by: Alex Gonzalez <alexg@balena.io>
+---
+ arch/arm64/configs/iot-gate-imx8.config | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/configs/iot-gate-imx8.config b/arch/arm64/configs/iot-gate-imx8.config
+index 56802059df32..34741b8e8e23 100644
+--- a/arch/arm64/configs/iot-gate-imx8.config
++++ b/arch/arm64/configs/iot-gate-imx8.config
+@@ -1,4 +1,4 @@
+-CONFIG_LOCALVERSION="-iot-gate-imx8m-3.2.2"
++CONFIG_LOCALVERSION="-iot-gate-imx8m-3.2.2.1"
+ CONFIG_LOCALVERSION_AUTO=n
+ CONFIG_BT_BCM=n
+ CONFIG_BT_HCIBTUSB_BCM=n

--- a/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab/soc-imx8m-Enable-OCOTP-clock-before-reading-the-regi.patch
+++ b/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab/soc-imx8m-Enable-OCOTP-clock-before-reading-the-regi.patch
@@ -1,0 +1,63 @@
+From: Xiaolei Wang <xiaolei.wang@windriver.com>
+Date: Fri, 28 Oct 2022 12:14:18 +0800
+Subject: [PATCH] soc: imx8m: Enable OCOTP clock before reading the register
+
+Commit 7d981405d0fd ("soc: imx8m: change to use platform driver") ever
+removed the dependency on bootloader for enabling OCOTP clock.  It
+helped to fix a kexec kernel hang issue.  But unfortunately it caused
+a regression on CAAM driver and got reverted.
+
+This is the second try to enable the OCOTP clock by directly calling
+clock API instead of indirectly enabling the clock via nvmem API.
+
+Fixes: ac34de14ac30 ("Revert "soc: imx8m: change to use platform driver"")
+Signed-off-by: Xiaolei Wang <xiaolei.wang@windriver.com>
+Reviewed-by: Lucas Stach <l.stach@pengutronix.de>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ drivers/soc/imx/soc-imx8m.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/soc/imx/soc-imx8m.c b/drivers/soc/imx/soc-imx8m.c
+index cc57a384d74d..28144c699b0c 100644
+--- a/drivers/soc/imx/soc-imx8m.c
++++ b/drivers/soc/imx/soc-imx8m.c
+@@ -11,6 +11,7 @@
+ #include <linux/platform_device.h>
+ #include <linux/arm-smccc.h>
+ #include <linux/of.h>
++#include <linux/clk.h>
+ 
+ #define REV_B1				0x21
+ 
+@@ -56,6 +57,7 @@ static u32 __init imx8mq_soc_revision(void)
+ 	void __iomem *ocotp_base;
+ 	u32 magic;
+ 	u32 rev;
++	struct clk *clk;
+ 
+ 	np = of_find_compatible_node(NULL, NULL, "fsl,imx8mq-ocotp");
+ 	if (!np)
+@@ -63,6 +65,13 @@ static u32 __init imx8mq_soc_revision(void)
+ 
+ 	ocotp_base = of_iomap(np, 0);
+ 	WARN_ON(!ocotp_base);
++	clk = of_clk_get_by_name(np, NULL);
++	if (!clk) {
++		WARN_ON(!clk);
++		return 0;
++	}
++
++	clk_prepare_enable(clk);
+ 
+ 	/*
+ 	 * SOC revision on older imx8mq is not available in fuses so query
+@@ -79,6 +88,8 @@ static u32 __init imx8mq_soc_revision(void)
+ 	soc_uid <<= 32;
+ 	soc_uid |= readl_relaxed(ocotp_base + OCOTP_UID_LOW);
+ 
++	clk_disable_unprepare(clk);
++	clk_put(clk);
+ 	iounmap(ocotp_base);
+ 	of_node_put(np);
+ 

--- a/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab/soc-imx8m-Enable-OCOTP-clock-for-imx8mm-before-readi.patch
+++ b/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab/soc-imx8m-Enable-OCOTP-clock-for-imx8mm-before-readi.patch
@@ -1,0 +1,57 @@
+From: Nathan Rossi <nathan.rossi@digi.com>
+Date: Mon, 14 Aug 2023 01:57:00 +0000
+Subject: [PATCH] soc: imx8m: Enable OCOTP clock for imx8mm before reading
+ registers
+
+Commit 836fb30949d9 ("soc: imx8m: Enable OCOTP clock before reading the
+register") added configuration to enable the OCOTP clock before
+attempting to read from the associated registers.
+
+This same kexec issue is present with the imx8m SoCs that use the
+imx8mm_soc_uid function (e.g. imx8mp). This requires the imx8mm_soc_uid
+function to configure the OCOTP clock before accessing the associated
+registers. This change implements the same clock enable functionality
+that is present in the imx8mq_soc_revision function for the
+imx8mm_soc_uid function.
+
+Signed-off-by: Nathan Rossi <nathan.rossi@digi.com>
+Reviewed-by: Fabio Estevam <festevam@gmail.com>
+Fixes: 836fb30949d9 ("soc: imx8m: Enable OCOTP clock before reading the register")
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ drivers/soc/imx/soc-imx8m.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/drivers/soc/imx/soc-imx8m.c b/drivers/soc/imx/soc-imx8m.c
+index 1dcd243df567..ec87d9d878f3 100644
+--- a/drivers/soc/imx/soc-imx8m.c
++++ b/drivers/soc/imx/soc-imx8m.c
+@@ -100,6 +100,7 @@ static void __init imx8mm_soc_uid(void)
+ {
+ 	void __iomem *ocotp_base;
+ 	struct device_node *np;
++	struct clk *clk;
+ 	u32 offset = of_machine_is_compatible("fsl,imx8mp") ?
+ 		     IMX8MP_OCOTP_UID_OFFSET : 0;
+ 
+@@ -109,11 +110,20 @@ static void __init imx8mm_soc_uid(void)
+ 
+ 	ocotp_base = of_iomap(np, 0);
+ 	WARN_ON(!ocotp_base);
++	clk = of_clk_get_by_name(np, NULL);
++	if (IS_ERR(clk)) {
++		WARN_ON(IS_ERR(clk));
++		return;
++	}
++
++	clk_prepare_enable(clk);
+ 
+ 	soc_uid = readl_relaxed(ocotp_base + OCOTP_UID_HIGH + offset);
+ 	soc_uid <<= 32;
+ 	soc_uid |= readl_relaxed(ocotp_base + OCOTP_UID_LOW + offset);
+ 
++	clk_disable_unprepare(clk);
++	clk_put(clk);
+ 	iounmap(ocotp_base);
+ 	of_node_put(np);
+ }

--- a/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab/soc-imx8m-Fix-incorrect-check-for-of_clk_get_by_name.patch
+++ b/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab/soc-imx8m-Fix-incorrect-check-for-of_clk_get_by_name.patch
@@ -1,0 +1,29 @@
+From: Miaoqian Lin <linmq006@gmail.com>
+Date: Sat, 31 Dec 2022 13:58:48 +0400
+Subject: [PATCH] soc: imx8m: Fix incorrect check for of_clk_get_by_name()
+
+of_clk_get_by_name() returns error pointers instead of NULL.
+Use IS_ERR() checks the return value to catch errors.
+
+Fixes: 836fb30949d9 ("soc: imx8m: Enable OCOTP clock before reading the register")
+Signed-off-by: Miaoqian Lin <linmq006@gmail.com>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ drivers/soc/imx/soc-imx8m.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/soc/imx/soc-imx8m.c b/drivers/soc/imx/soc-imx8m.c
+index 28144c699b0c..32ed9dc88e45 100644
+--- a/drivers/soc/imx/soc-imx8m.c
++++ b/drivers/soc/imx/soc-imx8m.c
+@@ -66,8 +66,8 @@ static u32 __init imx8mq_soc_revision(void)
+ 	ocotp_base = of_iomap(np, 0);
+ 	WARN_ON(!ocotp_base);
+ 	clk = of_clk_get_by_name(np, NULL);
+-	if (!clk) {
+-		WARN_ON(!clk);
++	if (IS_ERR(clk)) {
++		WARN_ON(IS_ERR(clk));
+ 		return 0;
+ 	}
+ 

--- a/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab_5.15.%.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab_5.15.%.bbappend
@@ -8,6 +8,7 @@ SRC_URI:append = " \
     file://soc-imx8m-Enable-OCOTP-clock-before-reading-the-regi.patch \
     file://soc-imx8m-Fix-incorrect-check-for-of_clk_get_by_name.patch \
     file://soc-imx8m-Enable-OCOTP-clock-for-imx8mm-before-readi.patch \
+    file://iot-gate-imx8-release-3.2.2.1.patch \
 "
 
 # Fixes issue where cryptodev module is installed

--- a/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab_5.15.%.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-kernel/linux/linux-compulab_5.15.%.bbappend
@@ -1,6 +1,14 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/linux-compulab:"
+
 inherit kernel-resin
 
 DEPENDS += "rsync-native"
+
+SRC_URI:append = " \
+    file://soc-imx8m-Enable-OCOTP-clock-before-reading-the-regi.patch \
+    file://soc-imx8m-Fix-incorrect-check-for-of_clk_get_by_name.patch \
+    file://soc-imx8m-Enable-OCOTP-clock-for-imx8mm-before-readi.patch \
+"
 
 # Fixes issue where cryptodev module is installed
 # along with the kernel image in the initramfs


### PR DESCRIPTION
These fixes are backports from upstream 5.15.y stable branch. However, compulab has not released any BSP update above 5.15.32.

I made a quick attempt to update to both the `lf-5.15.52-2.1.0` tag and  the head of the `lf-5.15.y` branch in https://github.com/nxp-imx/linux-imx.git but I did not feel confident on the update.

In particular, Compulab reverts a bunch of upstream changes in https://github.com/compulab-yokneam/meta-bsp-imx8mm/blob/83e35485d61f398b3f2d7f3927a8a04dd9d21ca4/recipes-kernel/linux/compulab/imx8mm/0089-net-smsc95-Fix-phy-issue.patch to fix issues with the ethernet PHY.

That patch has to be removed for the update to apply cleanly, and solving the conflicts without a way to verify that the SMSC PHY works is difficult with the little details about the problem available in the commit.

So I opted just to backport these patches instead of updating to the head which can be done at a later time.

Also, merging these patches before adding balena bootloader support allow for users to update to this version first to have a kexec safe kernel that avoids problems with rollbacks.