### PR TITLE
imx-boot: do not use remove on tasks

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-bsp/imx-mkimage/imx-boot_%.bbappend
@@ -5,6 +5,12 @@ do_configure[nostamp] = "1"
 do_compile[depends] += "u-boot-compulab:do_deploy"
 do_compile[nostamp] = "1"
 
-do_install:remove() {
-    ln -fs ${BOOT_CONFIG_MACHINE}-${target} ${D}/boot/imx-boot
+do_install:prepend() {
+    for type in "${UBOOT_CONFIG}"; do
+        if [ -z "${BOOT_CONFIG_MACHINE}" ]; then
+            BOOT_CONFIG_MACHINE="${BOOT_NAME}-${MACHINE}-${type}.bin"
+        else
+            bbfatal "More than one U-boot is being built - please adapt"
+        fi
+    done
 }


### PR DESCRIPTION
The :remove bitbake keyword is meant to do word removals and here it is used to remove a whole line, which works, but could break at any time.

Replace by a prepend that defines the missing variables to fix the original install task.

Changelog-entry: fix imx-boot not to use remove on the install task