### PR TITLE
Customize poweroff

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,1 +1,3 @@
 IMAGE_ROOTFS_MAXSIZE = "40960"
+
+PACKAGE_INSTALL:append = " os-helpers-power"

--- a/layers/meta-balena-imx8mm/recipes-support/os-helpers/os-helpers.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-support/os-helpers/os-helpers.bbappend
@@ -1,0 +1,13 @@
+FILESEXTRAPATHS:append := ":${THISDIR}/${PN}"
+
+SRC_URI += " \
+    file://os-helpers-power \
+"
+
+PACKAGES += "${PN}-power"
+
+do_install:append() {
+	install -m 0775 ${WORKDIR}/os-helpers-power ${D}${libexecdir}
+}
+
+FILES:${PN}-power = "/usr/libexec/os-helpers-power"

--- a/layers/meta-balena-imx8mm/recipes-support/os-helpers/os-helpers/os-helpers-power
+++ b/layers/meta-balena-imx8mm/recipes-support/os-helpers/os-helpers/os-helpers-power
@@ -1,0 +1,5 @@
+os_helpers_shutdown() {
+	poweroff -f
+	sleep 30
+	fail "Unable to shutdown or reboot"
+}


### PR DESCRIPTION
This has gone unnoticed as what happens instead of poweroff is that the kernel oops and the device freezes. However, I am introducing reboot on panic configuration as part of the secure boot work, and with that configuration and without this patch the device reboots instead of powering down.