### PR TITLE
workflows: iot-gate-imx8-sb: remove non-sb runs

### DIFF
--- a/.github/workflows/iot-gate-imx8-sb.yml
+++ b/.github/workflows/iot-gate-imx8-sb.yml
@@ -64,7 +64,7 @@ jobs:
           "test_suite": ["os","cloud","hup"],
           "environment": ["balena-cloud.com"],
           "runs_on": [["ubuntu-latest"]],
-          "secure_boot": ["sb",""]
+          "secure_boot": ["sb"]
         }
       # Allow manual workflow runs to force finalize without checking previous test runs
       force-finalize: ${{ inputs.force-finalize || false }}


### PR DESCRIPTION
Closed i.MX devices are not able to run non secure-boot opt-in installers.

Changelog-entry: remove non-sb test runs for iot-gate-imx8-sb