### PR TITLE
balena-image: Set explicit partition size overrides for each machine

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-imx8mm/recipes-core/images/balena-image.inc
@@ -19,3 +19,7 @@ IMAGE_INSTALL:remove = "kernel-image"
 
 do_rootfs[depends] += " virtual/balena-bootloader:do_deploy"
 do_image_balenaos_img[depends] += " virtual/balena-bootloader:do_deploy"
+
+IMAGE_ROOTFS_SIZE:iot-gate-imx8 = "327680"
+BALENA_BOOT_SIZE:iot-gate-imx8 = "40960"
+BALENA_STATE_SIZE:iot-gate-imx8 = "20480"


### PR DESCRIPTION
## Summary
- Explicitly define `IMAGE_ROOTFS_SIZE`, `BALENA_BOOT_SIZE`, and `BALENA_STATE_SIZE` for every machine target in this repo, preserving any existing custom values and applying fallback defaults (327680/40960/20480) where none were previously set.