### PR TITLE
Install Intel AX210 rev66 firmware

### DIFF
--- a/layers/meta-balena-imx8mm/conf/layer.conf
+++ b/layers/meta-balena-imx8mm/conf/layer.conf
@@ -33,7 +33,7 @@ BBMASK += "meta-balena-hab/recipes-bsp/u-boot/u-boot-variscite.bbappend"
 BBMASK += "meta-balena-hab/recipes-kernel/linux/linux-variscite_%.bbappend"
 
 CORE_IMAGE_EXTRA_INSTALL:iot-gate-imx8 += " cl-uboot cl-deploy u-boot-script "
-CORE_IMAGE_EXTRA_INSTALL:iot-gate-imx8 += " u-boot-fw-utils modemmanager networkmanager linux-firmware-ax200 linux-firmware-ax210"
+CORE_IMAGE_EXTRA_INSTALL:iot-gate-imx8 += " u-boot-fw-utils modemmanager networkmanager linux-firmware-ax200"
 CORE_IMAGE_EXTRA_INSTALL:remove = "firmware-imx-sdma-imx7d"
 
 KERNEL_IMAGETYPE:iot-gate-imx8 = "Image.gz"

--- a/layers/meta-balena-imx8mm/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -2,7 +2,9 @@
 # iwlwifi for internal BT
 CONNECTIVITY_FIRMWARES:append = " \
     linux-firmware-iwlwifi-cc-a0 \
+    linux-firmware-iwlwifi-ty-a0 \
     linux-firmware-ibt-20 \
+    linux-firmware-ibt-41-41 \
 "
 
 # Fixes: nothing provides linux-firmware-bcm43143 needed by packagegroup-balena-connectivity-1.0-r0.all

--- a/layers/meta-balena-imx8mm/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-imx8mm/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -3,6 +3,16 @@ FILES:${PN}-iwlwifi-cc-a0 = " \
     ${nonarch_base_libdir}/firmware/iwlwifi-cc-a0-66.ucode* \
 "
 
+# Include only the maximum version supported
+# to avoid increasing the occupied rootfs space
+# by too much. With this addition the space taken
+# up by firmware increases from 2.7M to 3.6M as
+# reported by du -h.
+FILES:${PN}-iwlwifi-ty-a0 = " \
+    ${nonarch_base_libdir}/firmware/iwlwifi-ty-a0-gf-a0-66.ucode* \
+    ${nonarch_base_libdir}/firmware/iwlwifi-ty-a0-gf-a0.pnvm* \
+"
+
 FILES:${PN}-ax200 += " \
        ${nonarch_base_libdir}/firmware/iwlwifi-cc-a0-50.ucode* \
        ${nonarch_base_libdir}/firmware/iwlwifi-cc-a0-48.ucode* \


### PR DESCRIPTION
This PR adds back some of the firmware necessary for Intel AX210, which was no longer installed since v6.2 when it was packaged in meta-balena, causing the repository/BSP defined package linux-firmware-ax210 to become empty.

We install only v66 of the firmware, to avoid increasing the occupied rootfs space by too much. This change adds around 1MB of firmware back.