### PR TITLE
balena-image: Fix IMAGE_ROOTFS_SIZE override shadowing HAB build

### DIFF
--- a/layers/meta-balena-imx8mm/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-imx8mm/recipes-core/images/balena-image.inc
@@ -20,6 +20,12 @@ IMAGE_INSTALL:remove = "kernel-image"
 do_rootfs[depends] += " virtual/balena-bootloader:do_deploy"
 do_image_balenaos_img[depends] += " virtual/balena-bootloader:do_deploy"
 
-IMAGE_ROOTFS_SIZE:iot-gate-imx8 = "327680"
+# Only set for the non-signed build - meta-balena-hab sets its own
+# IMAGE_ROOTFS_SIZE for the HAB variant, and an override here would
+# always win over that and shrink it.
+python() {
+    if not d.getVar('SIGN_API'):
+        d.setVar('IMAGE_ROOTFS_SIZE:iot-gate-imx8', '327680')
+}
 BALENA_BOOT_SIZE:iot-gate-imx8 = "40960"
 BALENA_STATE_SIZE:iot-gate-imx8 = "20480"


### PR DESCRIPTION
## Summary
- `IMAGE_ROOTFS_SIZE:iot-gate-imx8` (added in #1093, merged to master) always wins over `meta-balena-hab`'s bare `IMAGE_ROOTFS_SIZE` global, which only applies to the secure-boot (HAB) build of this same machine. This silently shrank the secure-boot image's rootfs.
- Only set the override for the regular (non-signed) build, gated on `SIGN_API` being unset. The secure-boot build keeps using `meta-balena-hab`'s own value untouched.